### PR TITLE
Generalfixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_nat_gateway" "this" {
   count = var.enable_nat_gateway ? local.nat_gateway_count : 0
 
   allocation_id = element(local.nat_gateway_ips, (var.single_nat_gateway ? 0 : count.index))
-  subnet_id     = element(aws_subnet.public[*].id, (var.single_nat_gateway ? 0 : count.index))
+  subnet_id     = element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))
 
   tags = merge(tomap({
     "Name" = format("%s-%s", var.name, element(var.azs, (var.single_nat_gateway ? 0 : count.index)))

--- a/modules/aws-network-firewall/main.tf
+++ b/modules/aws-network-firewall/main.tf
@@ -1,5 +1,5 @@
 resource "aws_networkfirewall_firewall" "this" {
-  name                = "${var.firewall_name}"
+  name                = var.firewall_name
   description         = coalesce(var.description, var.firewall_name)
   firewall_policy_arn = aws_networkfirewall_firewall_policy.this.arn
   vpc_id              = var.vpc_id

--- a/modules/aws-network-firewall/main.tf
+++ b/modules/aws-network-firewall/main.tf
@@ -1,5 +1,5 @@
 resource "aws_networkfirewall_firewall" "this" {
-  name                = "${var.prefix}-nfw-${var.firewall_name}"
+  name                = "${var.firewall_name}"
   description         = coalesce(var.description, var.firewall_name)
   firewall_policy_arn = aws_networkfirewall_firewall_policy.this.arn
   vpc_id              = var.vpc_id

--- a/modules/aws-network-firewall/main.tf
+++ b/modules/aws-network-firewall/main.tf
@@ -39,7 +39,7 @@ resource "aws_networkfirewall_rule_group" "suricata_stateful_group" {
 
   rule_group {
     rules_source {
-      rules_string = file(var.suricata_stateful_rule_group[count.index]["rules_file"])
+      rules_string = try(file(var.suricata_stateful_rule_group[count.index]["rules_file"]), "")
     }
 
     dynamic "rule_variables" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -179,21 +179,21 @@ output "aws_nfw_endpoint_ids" {
 output "database_route_table_ids" {
   description = "List of IDs of database route tables"
   value = [
-    coalescelist(aws_route_table.database[*].id, aws_route_table.private[*].id)
+    try(coalescelist(aws_route_table.database[*].id, aws_route_table.private[*].id), "")
   ]
 }
 
 output "redshift_route_table_ids" {
   description = "List of IDs of redshift route tables"
   value = [
-    coalescelist(aws_route_table.redshift[*].id, aws_route_table.private[*].id)
+    try(coalescelist(aws_route_table.redshift[*].id, aws_route_table.private[*].id), "")
   ]
 }
 
 output "elasticache_route_table_ids" {
   description = "List of IDs of elasticache route tables"
   value = [
-    coalescelist(aws_route_table.elasticache[*].id, aws_route_table.private[*].id)
+    try(coalescelist(aws_route_table.elasticache[*].id, aws_route_table.private[*].id), "")
   ]
 }
 

--- a/routes.tf
+++ b/routes.tf
@@ -62,7 +62,7 @@ resource "aws_route" "aws_nfw_igw_rt" {
   count = var.deploy_aws_nfw ? length(var.firewall_subnets) : 0
 
   route_table_id         = aws_route_table.aws_nfw_igw_rtb[0].id
-  destination_cidr_block = var.public_subnets[count.index]
+  destination_cidr_block = element(values(var.private_subnets), count.index)
   vpc_endpoint_id        = module.aws_network_firewall[0].endpoint_id[count.index]
 
   timeouts {

--- a/routes.tf
+++ b/routes.tf
@@ -45,7 +45,7 @@ resource "aws_route" "aws_nfw_public_internet" {
   timeouts {
     create = "5m"
   }
-  depends_on = [ module.aws_network_firewall ]
+  depends_on = [module.aws_network_firewall]
 }
 
 resource "aws_route_table" "aws_nfw_igw_rtb" {
@@ -110,7 +110,7 @@ resource "aws_route" "nfw_public_custom" {
   destination_cidr_block     = lookup(var.public_custom_routes[floor(count.index / length(aws_route_table.public))], "destination_cidr_block", null)
   destination_prefix_list_id = lookup(var.public_custom_routes[floor(count.index / length(aws_route_table.public))], "destination_prefix_list_id", null)
 
-  vpc_endpoint_id      = var.public_custom_routes[floor(count.index / length(aws_route_table.public))]["internet_route"] ? module.aws_network_firewall[0].endpoint_id[index(aws_route_table.public, element(aws_route_table.public, count.index))] : null
+  vpc_endpoint_id = var.public_custom_routes[floor(count.index / length(aws_route_table.public))]["internet_route"] ? module.aws_network_firewall[0].endpoint_id[index(aws_route_table.public, element(aws_route_table.public, count.index))] : null
 
   timeouts {
     create = "5m"

--- a/subnets.tf
+++ b/subnets.tf
@@ -20,12 +20,13 @@ resource "aws_subnet" "firewall" {
 ################
 resource "aws_subnet" "public" {
   #checkov:skip=CKV_AWS_130: "Ensure VPC subnets do not assign public IP by default" - This is a public subet.
-  count = length(var.public_subnets) > 0 && (!var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = var.public_subnets[
-    count.index
-  ]
+  #count = length(var.public_subnets) > 0 && (!var.one_nat_gateway_per_az || length(var.public_subnets) >= length(var.azs)) ? length(var.public_subnets) : 0
+  count = length(var.public_subnets) > 0 ? length(var.public_subnets) : 0
+
+
+  vpc_id                  = local.vpc_id
+  cidr_block              = var.public_subnets[count.index]
   availability_zone       = element(var.azs, count.index)
   map_public_ip_on_launch = var.map_public_ip_on_launch
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -4,14 +4,12 @@
 resource "aws_subnet" "firewall" {
   count = length(var.firewall_subnets) > 0 ? length(var.firewall_subnets) : 0
 
-  vpc_id = local.vpc_id
-  #cidr_block = var.firewall_subnets[count.index]
+  vpc_id            = local.vpc_id
   cidr_block        = element(values(var.firewall_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.firewall_subnets), count.index))
-    #"Name" = format("%s-${lower(var.firewall_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.firewall_subnet_name_tag)
 }
 
@@ -33,7 +31,6 @@ resource "aws_subnet" "public" {
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.public_subnets), count.index))
-    #"Name" = format("%s-${lower(var.public_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.public_subnet_tags)
 }
 
@@ -49,8 +46,6 @@ resource "aws_subnet" "private" {
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.private_subnets), count.index))
-    #"Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
-    #"Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", var.private_subnets[count.index])[0]), 3)), element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 
@@ -67,7 +62,6 @@ resource "aws_subnet" "database" {
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.database_subnets), count.index))
-    #"Name" = format("%s-${var.database_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.database_subnet_tags)
 }
 
@@ -89,14 +83,12 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_subnet" "redshift" {
   count = length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  vpc_id = local.vpc_id
-  #cidr_block        = var.redshift_subnets[count.index]
+  vpc_id            = local.vpc_id
   cidr_block        = element(values(var.redshift_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.redshift_subnets), count.index))
-    #"Name" = format("%s-${var.redshift_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.redshift_subnet_tags)
 }
 
@@ -118,14 +110,12 @@ resource "aws_redshift_subnet_group" "redshift" {
 resource "aws_subnet" "elasticache" {
   count = length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  vpc_id = local.vpc_id
-  #cidr_block        = var.elasticache_subnets[count.index]
+  vpc_id            = local.vpc_id
   cidr_block        = element(values(var.elasticache_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
     "Name" = lower(element(keys(var.elasticache_subnets), count.index))
-    #"Name" = format("%s-${var.elasticache_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.elasticache_subnet_tags)
 }
 
@@ -143,14 +133,11 @@ resource "aws_elasticache_subnet_group" "elasticache" {
 resource "aws_subnet" "intra" {
   count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
-  vpc_id = local.vpc_id
-  #cidr_block        = var.intra_subnets[count.index]
+  vpc_id            = local.vpc_id
   cidr_block        = element(values(var.intra_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
-  # tags = merge(tomap("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)
   tags = merge(tomap({
     "Name" = lower(element(keys(var.intra_subnets), count.index))
-    #"Name" = format("%s-${var.intra_subnet_name_tag[count.index]}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.intra_subnet_tags)
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -49,7 +49,6 @@ resource "aws_subnet" "private" {
 
   tags = merge(tomap({
     "Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
-    #"Name" = format("%s-${lower(var.private_subnet_name_tag[count.index])}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -42,12 +42,13 @@ resource "aws_subnet" "private" {
   count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.private_subnets[count.index]
+  cidr_block = values(var.private_subnets[count.index])
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
+    Name = lower(keys(var.private_subnets[count.index]))
     #"Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
-    "Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", var.private_subnets[count.index])[0]), 3)), element(var.azs, count.index))
+    #"Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", var.private_subnets[count.index])[0]), 3)), element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -5,13 +5,13 @@ resource "aws_subnet" "firewall" {
   count = length(var.firewall_subnets) > 0 ? length(var.firewall_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.firewall_subnets[
-    count.index
-  ]
+  #cidr_block = var.firewall_subnets[count.index]
+  cidr_block        = element(values(var.firewall_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${lower(var.firewall_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.firewall_subnets), count.index))
+    #"Name" = format("%s-${lower(var.firewall_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.firewall_subnet_name_tag)
 }
 
@@ -25,20 +25,22 @@ resource "aws_subnet" "public" {
   count = length(var.public_subnets) > 0 ? length(var.public_subnets) : 0
 
 
-  vpc_id                  = local.vpc_id
-  cidr_block              = var.public_subnets[count.index]
+  vpc_id = local.vpc_id
+  #cidr_block              = var.public_subnets[count.index]
+  cidr_block              = element(values(var.public_subnets), count.index)
   availability_zone       = element(var.azs, count.index)
   map_public_ip_on_launch = var.map_public_ip_on_launch
 
   tags = merge(tomap({
-    "Name" = format("%s-${lower(var.public_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.public_subnets), count.index))
+    #"Name" = format("%s-${lower(var.public_subnet_suffix)}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.public_subnet_tags)
 }
 
 #################
 # Private subnet
 #################
-resource "aws_subnet" "private" {
+resource "aws_subnet" "prikvate" {
   count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
   vpc_id            = local.vpc_id
@@ -58,12 +60,14 @@ resource "aws_subnet" "private" {
 resource "aws_subnet" "database" {
   count = length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.database_subnets[count.index]
+  vpc_id = local.vpc_id
+  #cidr_block        = var.database_subnets[count.index]
+  cidr_block        = element(values(var.database_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${var.database_subnet_suffix}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.database_subnets), count.index))
+    #"Name" = format("%s-${var.database_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.database_subnet_tags)
 }
 
@@ -85,12 +89,14 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_subnet" "redshift" {
   count = length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.redshift_subnets[count.index]
+  vpc_id = local.vpc_id
+  #cidr_block        = var.redshift_subnets[count.index]
+  cidr_block        = element(values(var.redshift_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${var.redshift_subnet_suffix}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.redshift_subnets), count.index))
+    #"Name" = format("%s-${var.redshift_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.redshift_subnet_tags)
 }
 
@@ -112,12 +118,14 @@ resource "aws_redshift_subnet_group" "redshift" {
 resource "aws_subnet" "elasticache" {
   count = length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.elasticache_subnets[count.index]
+  vpc_id = local.vpc_id
+  #cidr_block        = var.elasticache_subnets[count.index]
+  cidr_block        = element(values(var.elasticache_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${var.elasticache_subnet_suffix}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.elasticache_subnets), count.index))
+    #"Name" = format("%s-${var.elasticache_subnet_suffix}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.elasticache_subnet_tags)
 }
 
@@ -135,12 +143,14 @@ resource "aws_elasticache_subnet_group" "elasticache" {
 resource "aws_subnet" "intra" {
   count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
-  vpc_id            = local.vpc_id
-  cidr_block        = var.intra_subnets[count.index]
+  vpc_id = local.vpc_id
+  #cidr_block        = var.intra_subnets[count.index]
+  cidr_block        = element(values(var.intra_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   # tags = merge(tomap("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)
   tags = merge(tomap({
-    "Name" = format("%s-${var.intra_subnet_name_tag[count.index]}-%s", var.name, element(var.azs, count.index))
+    "Name" = lower(element(keys(var.intra_subnets), count.index))
+    #"Name" = format("%s-${var.intra_subnet_name_tag[count.index]}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.intra_subnet_tags)
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -48,7 +48,8 @@ resource "aws_subnet" "private" {
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${lower(var.private_subnet_name_tag[count.index])}-%s", var.name, element(var.azs, count.index))
+    "Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
+    #"Name" = format("%s-${lower(var.private_subnet_name_tag[count.index])}-%s", var.name, element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -41,12 +41,12 @@ resource "aws_subnet" "public" {
 resource "aws_subnet" "private" {
   count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = values(var.private_subnets[count.index])
+  vpc_id            = local.vpc_id
+  cidr_block        = element(values(var.private_subnets), count.index)
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    Name = lower(keys(var.private_subnets[count.index]))
+    "Name" = lower(element(keys(var.private_subnets), count.index))
     #"Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
     #"Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", var.private_subnets[count.index])[0]), 3)), element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
@@ -58,8 +58,8 @@ resource "aws_subnet" "private" {
 resource "aws_subnet" "database" {
   count = length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = var.database_subnets[count.index]
+  vpc_id            = local.vpc_id
+  cidr_block        = var.database_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -85,8 +85,8 @@ resource "aws_db_subnet_group" "database" {
 resource "aws_subnet" "redshift" {
   count = length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = var.redshift_subnets[count.index]
+  vpc_id            = local.vpc_id
+  cidr_block        = var.redshift_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -99,7 +99,7 @@ resource "aws_redshift_subnet_group" "redshift" {
 
   name        = var.name
   description = "Redshift subnet group for ${var.name}"
-  subnet_ids = [aws_subnet.redshift[*].id]
+  subnet_ids  = [aws_subnet.redshift[*].id]
 
   tags = merge(tomap({
     "Name" = format("%s", var.name)
@@ -112,8 +112,8 @@ resource "aws_redshift_subnet_group" "redshift" {
 resource "aws_subnet" "elasticache" {
   count = length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = var.elasticache_subnets[count.index]
+  vpc_id            = local.vpc_id
+  cidr_block        = var.elasticache_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -135,8 +135,8 @@ resource "aws_elasticache_subnet_group" "elasticache" {
 resource "aws_subnet" "intra" {
   count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
-  vpc_id = local.vpc_id
-  cidr_block = var.intra_subnets[count.index]
+  vpc_id            = local.vpc_id
+  cidr_block        = var.intra_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   # tags = merge(tomap("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)

--- a/subnets.tf
+++ b/subnets.tf
@@ -46,7 +46,8 @@ resource "aws_subnet" "private" {
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
-    "Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
+    #"Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
+    "Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", cidr_block)[0]), 3)), element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -47,7 +47,7 @@ resource "aws_subnet" "private" {
 
   tags = merge(tomap({
     #"Name" = format("%s-${lower(element(values(var.private_subnet_name_tag), count.index))}-%s", var.name, element(var.azs, count.index))
-    "Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", cidr_block)[0]), 3)), element(var.azs, count.index))
+    "Name" = format("%s-%s-%s", var.name, lookup(var.private_subnet_name_tag, element(split(".", split("/", var.private_subnets[count.index])[0]), 3)), element(var.azs, count.index))
   }), var.tags, var.private_subnet_tags)
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -40,7 +40,7 @@ resource "aws_subnet" "public" {
 #################
 # Private subnet
 #################
-resource "aws_subnet" "prikvate" {
+resource "aws_subnet" "private" {
   count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
   vpc_id            = local.vpc_id

--- a/subnets.tf
+++ b/subnets.tf
@@ -42,9 +42,7 @@ resource "aws_subnet" "private" {
   count = length(var.private_subnets) > 0 ? length(var.private_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.private_subnets[
-    count.index
-  ]
+  cidr_block = var.private_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -59,9 +57,7 @@ resource "aws_subnet" "database" {
   count = length(var.database_subnets) > 0 ? length(var.database_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.database_subnets[
-    count.index
-  ]
+  cidr_block = var.database_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -88,9 +84,7 @@ resource "aws_subnet" "redshift" {
   count = length(var.redshift_subnets) > 0 ? length(var.redshift_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.redshift_subnets[
-    count.index
-  ]
+  cidr_block = var.redshift_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -103,9 +97,7 @@ resource "aws_redshift_subnet_group" "redshift" {
 
   name        = var.name
   description = "Redshift subnet group for ${var.name}"
-  subnet_ids = [
-    aws_subnet.redshift[*].id
-  ]
+  subnet_ids = [aws_subnet.redshift[*].id]
 
   tags = merge(tomap({
     "Name" = format("%s", var.name)
@@ -119,9 +111,7 @@ resource "aws_subnet" "elasticache" {
   count = length(var.elasticache_subnets) > 0 ? length(var.elasticache_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.elasticache_subnets[
-    count.index
-  ]
+  cidr_block = var.elasticache_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   tags = merge(tomap({
@@ -144,9 +134,7 @@ resource "aws_subnet" "intra" {
   count = length(var.intra_subnets) > 0 ? length(var.intra_subnets) : 0
 
   vpc_id = local.vpc_id
-  cidr_block = var.intra_subnets[
-    count.index
-  ]
+  cidr_block = var.intra_subnets[count.index]
   availability_zone = element(var.azs, count.index)
 
   # tags = merge(tomap("Name", format("%s-intra-%s", var.name, element(var.azs, count.index))), var.tags, var.intra_subnet_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -209,7 +209,7 @@ variable "firewall_subnets" {
 variable "private_subnets" {
   description = "A list of private subnets inside the VPC"
   default     = []
-  type        = list(string)
+  type        = map(string)
 }
 
 variable "database_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -208,7 +208,7 @@ variable "firewall_subnets" {
 
 variable "private_subnets" {
   description = "A list of private subnets inside the VPC"
-  default     = []
+  default     = {}
   type        = map(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -196,14 +196,14 @@ variable "elasticache_subnet_suffix" {
 
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC"
-  default     = []
-  type        = list(string)
+  default     = {}
+  type        = map(string)
 }
 
 variable "firewall_subnets" {
   description = "A list of firewall subnets inside the VPC"
-  default     = []
-  type        = list(string)
+  default     = {}
+  type        = map(string)
 }
 
 variable "private_subnets" {
@@ -213,21 +213,21 @@ variable "private_subnets" {
 }
 
 variable "database_subnets" {
-  type        = list(string)
   description = "A list of database subnets"
-  default     = []
+  default     = {}
+  type        = map(string)
 }
 
 variable "redshift_subnets" {
-  type        = list(string)
   description = "A list of redshift subnets"
-  default     = []
+  default     = {}
+  type        = map(string)
 }
 
 variable "elasticache_subnets" {
-  type        = list(string)
   description = "A list of elasticache subnets"
-  default     = []
+  default     = {}
+  type        = map(string)
 }
 
 variable "create_database_subnet_route_table" {
@@ -249,9 +249,9 @@ variable "create_elasticache_subnet_route_table" {
 }
 
 variable "intra_subnets" {
-  type        = list(string)
   description = "A list of intra subnets"
-  default     = []
+  default     = {}
+  type        = map(string)
 }
 
 variable "create_database_subnet_group" {
@@ -379,36 +379,6 @@ variable "vpc_tags" {
 
 variable "igw_tags" {
   description = "Additional tags for the internet gateway"
-  default     = {}
-  type        = map(string)
-}
-
-variable "public_subnet_tags" {
-  description = "Additional tags for the public subnets"
-  default     = {}
-  type        = map(string)
-}
-
-variable "firewall_subnet_name_tag" {
-  description = "Additional name tag for the firewall subnets"
-  default     = {}
-  type        = map(string)
-}
-
-variable "private_subnet_tags" {
-  description = "Additional tags for the private subnets"
-  default     = {}
-  type        = map(string)
-}
-
-variable "private_subnet_name_tag" {
-  description = "Additional name tag for the private subnets"
-  default     = {}
-  type        = map(string)
-}
-
-variable "intra_subnet_name_tag" {
-  description = "Additional name tag for the intranet subnets"
   default     = {}
   type        = map(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -383,6 +383,24 @@ variable "igw_tags" {
   type        = map(string)
 }
 
+variable "public_subnet_tags" {
+  description = "Additional tags for the public subnets"
+  default     = {}
+  type        = map(string)
+}
+
+variable "firewall_subnet_name_tag" {
+  description = "Additional name tag for the firewall subnets"
+  default     = {}
+  type        = map(string)
+}
+
+variable "private_subnet_tags" {
+  description = "Additional tags for the private subnets"
+  default     = {}
+  type        = map(string)
+}
+
 variable "public_route_table_tags" {
   description = "Additional tags for the public route tables"
   default     = {}


### PR DESCRIPTION
- Refactored to pass a map of name -> CIDR for private, public, and firewall subnets for easier passing of the `name` tag to module
- Add try logic to enhance troubleshooting
- Fixed index issues when running on terraform 1.5.5
- Removed legacy tagging map for private subnets