### PR TITLE
Use count.index for route_table_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ The variables can be further inspected to see what parameters and types are expe
 | <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | List of IDs of private route tables - including database route table IDs, as the database uses the private route tables |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | List of IDs of private subnets |
 | <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | List of cidr\_blocks of private subnets |
+| <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | List of IDs of public route tables |
 | <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | List of IDs of public subnets |
 | <a name="output_public_subnets_cidr_blocks"></a> [public\_subnets\_cidr\_blocks](#output\_public\_subnets\_cidr\_blocks) | List of cidr\_blocks of public subnets |
 | <a name="output_redshift_route_table_ids"></a> [redshift\_route\_table\_ids](#output\_redshift\_route\_table\_ids) | List of IDs of redshift route tables |

--- a/routes.tf
+++ b/routes.tf
@@ -14,7 +14,7 @@ resource "aws_route_table" "public" {
 resource "aws_route" "public_internet_gateway" {
   count = var.deploy_aws_nfw ? 0 : length(var.public_subnets)
 
-  route_table_id         = aws_route_table.public[0].id
+  route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.this[0].id
 


### PR DESCRIPTION
# Routes
![image](https://github.com/user-attachments/assets/121d0310-e21d-44dd-9b9a-cf76b8e57838)

Because the index is always [0] instead of "[count.index]", the public routes are not properly created and will attempt to create a route for one route table instead of "each" route table (see screenshot).