### PR TITLE
FIX - NFW Default Ruleset

### DIFF
--- a/modules/aws-network-firewall/nfw-base-suricata-rules.json
+++ b/modules/aws-network-firewall/nfw-base-suricata-rules.json
@@ -42,4 +42,4 @@ drop ip $EXTERNAL_NET any -> $HOME_NET any (msg:"Drop all other non-TCP traffic"
 # Drop all other traffic
 drop tcp any any -> any any (msg:"Deny all other TCP traffic"; flow:established; sid:1999 ; rev:1;)
 # Drop TLS1.1 or lower traffic
-alert tls any any -> any any (msg:"TLS 1.0 or 1.1"; ssl_version:tls1.0,tls1.1; sid:2000;)
+reject tls any any -> any any (msg:"TLS 1.0 or 1.1"; ssl_version:tls1.0,tls1.1; sid:2000;)

--- a/modules/aws-network-firewall/nfw-base-suricata-rules.json
+++ b/modules/aws-network-firewall/nfw-base-suricata-rules.json
@@ -10,11 +10,17 @@ pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".micro
 pass http $HOME_NET any -> $EXTERNAL_NET 80 (http.host; dotprefix; content:".windowsupdate.com"; endswith; msg:"Pass HTTP to .windowsupdate.com"; sid:1005; rev:1;)
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".windowsupdate.com"; endswith; msg:"Pass TLS to .windowsupdate.com"; sid:1006; rev:1;)
 
+# Elastic Domains
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".elastic-cloud.com"; endswith; msg:"Pass TLS to .elastic-cloud.com"; sid:1007; rev:1;)
+
 # Nessus Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".nessus.org"; endswith; msg:"Pass TLS to .nessus.org"; sid:1008; rev:1;)
 
 # Trend Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".trendmicro.com"; endswith; msg:"Pass TLS to .trendmicro.com"; sid:1009; rev:1;)
+
+# Splunk Updates Servers
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".splunk.com"; endswith; msg:"Pass TLS to .splunk.com"; sid:1010; rev:1;)
 
 # Jira Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".atlassian.com"; endswith; msg:"Pass TLS to .atlassian.com"; sid:1011; rev:1;)

--- a/modules/aws-network-firewall/nfw-base-suricata-rules.json
+++ b/modules/aws-network-firewall/nfw-base-suricata-rules.json
@@ -1,15 +1,14 @@
 # Allow TCP traffic
 pass tcp $EXTERNAL_NET any -> $HOME_NET 22 (msg:"Allow inbound SSH - ONLY FOR PACKER DISABLE AFTER IMAGES ARE BUILT"; flow:established; sid:103; rev:1;)
 # Amazon domains
-pass http $HOME_NET any -> $EXTERNAL_NET 80 (http.host; dotprefix; content:".amazonaws.com"; endswith; msg:"Pass HTTP to .amazonaws.com"; sid:1001; rev:1;)
-pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".amazonaws.com"; endswith; msg:"Pass TLS to .amazonaws.com"; sid:1002; rev:1;)
+pass http $HOME_NET any -> any 80 (http.host; dotprefix; content:".us-gov-west-1.amazonaws.com"; endswith; msg:"Pass HTTP to .amazonaws.com"; sid:1001; rev:1;)
+pass tls $HOME_NET any -> any 443 (tls.sni; dotprefix; content:".us-gov-west-1.amazonaws.com"; endswith; msg:"Pass TLS to .amazonaws.com"; sid:1002; rev:2;)
+pass http $HOME_NET any -> 169.254.169.254 80 (sid:1801; rev:1;)
 # Microsoft domains
 pass http $HOME_NET any -> $EXTERNAL_NET 80 (http.host; dotprefix; content:".microsoft.com"; endswith; msg:"Pass HTTP to .microsoft.com"; sid:1003; rev:1;)
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".microsoft.com"; endswith; msg:"Pass TLS to .microsoft.com"; sid:1004; rev:1;)
 pass http $HOME_NET any -> $EXTERNAL_NET 80 (http.host; dotprefix; content:".windowsupdate.com"; endswith; msg:"Pass HTTP to .windowsupdate.com"; sid:1005; rev:1;)
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".windowsupdate.com"; endswith; msg:"Pass TLS to .windowsupdate.com"; sid:1006; rev:1;)
-# Elastic Domains
-pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".elastic-cloud.com"; endswith; msg:"Pass TLS to .elastic-cloud.com"; sid:1007; rev:1;)
 
 # Nessus Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".nessus.org"; endswith; msg:"Pass TLS to .nessus.org"; sid:1008; rev:1;)
@@ -17,15 +16,24 @@ pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".nessu
 # Trend Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".trendmicro.com"; endswith; msg:"Pass TLS to .trendmicro.com"; sid:1009; rev:1;)
 
-# Splunk Updates Servers
-pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".splunk.com"; endswith; msg:"Pass TLS to .splunk.com"; sid:1010; rev:1;)
-
 # Jira Update Servers
 pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:".atlassian.com"; endswith; msg:"Pass TLS to .atlassian.com"; sid:1011; rev:1;)
+
+# Burp Suite Enterprise Update and Licensing
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:"portswigger.net"; endswith; msg:"Pass TLS to portswigger.net"; sid:1012; rev:1;)
+
+# GitLab Self-Hosted - Update, Package, and Licensing
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:"gitlab.com"; endswith; msg:"Pass TLS to gitlab.com"; sid:1013; rev:1;)
+
+# GitLab Registry
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:"registry.gitlab.com"; endswith; msg:"Pass TLS to registry.gitlab.com"; sid:1014; rev:1;)
+
+# GitLab Packages
+pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; dotprefix; content:"packages.gitlab.com"; endswith; msg:"Pass TLS to packages.gitlab.com"; sid:1015; rev:1;)
 
 # Drop other traffic
 drop ip $EXTERNAL_NET any -> $HOME_NET any (msg:"Drop all other non-TCP traffic"; ip_proto:!TCP; sid:1998; rev:1;)
 # Drop all other traffic
-drop tcp any any -> any any (msg:"Deny all other TCP traffic"; sid: ; rev:1;)
+drop tcp any any -> any any (msg:"Deny all other TCP traffic"; flow:established; sid:1999 ; rev:1;)
 # Drop TLS1.1 or lower traffic
-reject tls any any -> any any (msg:"TLS 1.0 or 1.1"; ssl_version:tls1.0,tls1.1; sid:1999;)
+alert tls any any -> any any (msg:"TLS 1.0 or 1.1"; ssl_version:tls1.0,tls1.1; sid:2000;)


### PR DESCRIPTION
FIX - Encrypted SSM Sessions were being blocked by the old NFW rules in place. Modified AWS domains to include region. Chose us-gov-west-1 as a default since majority of clients use this region.