### PR TITLE
feat: allow VPN custom names

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module "mgmt_vpc" {
 
 > Note: If networks are being created with the goal of peering, it is best practice to build and deploy those resources within the same Terraform state. This allows for efficient referencing of peer subnets and CIDRs to facilitate a proper routing architecture. Please refer to the 'example' folder for example files needed on the parent module calling this PAK based on the deployment requirements.
 
-## Required inputs
+## Inputs
 
 | Input | Description | Example |
 |---|---|---|
@@ -104,6 +104,7 @@ module "mgmt_vpc" {
 | single_nat_gateway | If `true`, only deploys a single NAT gateway, shared between all private subnets | `false` |
 | one_nat_gateway_per_az | If `true`, deploys only one NAT gateway per Availability Zone, shared between all private subnets in that AZ | `true` |
 | enable_vpn_gateway | If `true`, creates a VPN gateway resource attached to the VPC | `false` |
+| vpn_gateway_custom_name | (Optional) If set, this replaces the default generated name of the AWS VPN with the provided value  | `"mgmt-prod-vpn"` |
 | enable_dns_hostnames | If `true`, enables DNS hostnames in the Default VPC | `false` |
 | flow_log_destination_type | The type of flow log destination. msut be one of `"s3"` or `"cloud-watch-logs"` | `"cloud-watch-logs"` |
 | cloudwatch_log_group_retention_in_days | The length of time, in days, to retain CloudWatch logs | `30`|

--- a/main.tf
+++ b/main.tf
@@ -190,9 +190,11 @@ resource "aws_vpn_gateway" "this" {
 
   vpc_id = local.vpc_id
 
-  tags = merge(tomap({
-    "Name" = format("%s", var.resource_prefix)
-  }), var.tags, var.vpn_gateway_tags)
+  tags = (
+    var.vpn_gateway_custom_name != null ?
+    merge(tomap({ "Name" = format("%s", var.vpn_gateway_custom_name) }), var.tags, var.vpn_gateway_tags) :
+    merge(tomap({ "Name" = format("%s", var.resource_prefix) }), var.tags, var.vpn_gateway_tags)
+  )
 }
 
 resource "aws_vpn_gateway_attachment" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -299,6 +299,11 @@ variable "enable_vpn_gateway" {
   type        = bool
 }
 
+variable "vpn_gateway_custom_name" {
+  description = "Specifies a custom name to assign to the VPN; if not set, a name will be generated from var.resource_prefix"
+  default     = null
+}
+
 variable "flow_log_destination_arn" {
   description = "The ARN of the Cloudwatch log destination for Flow Logs"
   type        = string


### PR DESCRIPTION
Adds an new **optional** input variable, `vpn_gateway_custom_name` which allows explicit definition of the name to assign to the VPN gateway:
- If `vpn_gateway_custom_name` is set to any value, that value is assigned as the `Name` tag on the VPN gateway resource
- If `vpn_gateway_custom_name` is left undefined, the default module-generated name is assigned instead (i.e. the current behavior of the module remains unchanged)

This change has been tested and successfully deployed in a client environment.

Deployments using v3.0.0 or v3.0.1 of the module can upgrade to this version without changes to the code.